### PR TITLE
Update content and styling of new account page

### DIFF
--- a/app/assets/stylesheets/accounts.scss
+++ b/app/assets/stylesheets/accounts.scss
@@ -1,0 +1,22 @@
+.account-form {
+  margin: 0 10px 30px;
+
+  h1 {
+    font-size: 2em;
+    margin-bottom: 30px;
+  }
+
+  label,
+  .actions {
+    text-align: right;
+  }
+
+  .actions .btn {
+    margin-left: 10px;
+  }
+
+  .help-block {
+    margin-bottom: 20px;
+    margin-top: 5px;
+  }
+}

--- a/app/assets/stylesheets/sufia.scss
+++ b/app/assets/stylesheets/sufia.scss
@@ -10,6 +10,7 @@
 @import "font-awesome";
 @import "sufia/sufia";
 @import "lerna";
+@import "accounts";
 @import "viewer";
 
 @import "blacklight_gallery/gallery";

--- a/app/views/accounts/_new_form.html.erb
+++ b/app/views/accounts/_new_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_for(@account, class: 'form') do |f| %>
   <% if @account.errors.any? %>
-    <div id="error_explanation">
-      <h2><%= pluralize(@account.errors.count, "error") %> prohibited this account from being saved:</h2>
+    <div id="error_explanation" class="alert alert-danger">
+      <%= pluralize(@account.errors.count, "error") %> prohibited this repository from being saved:
 
       <ul>
       <% @account.errors.full_messages.each do |message| %>
@@ -10,13 +10,24 @@
       </ul>
     </div>
   <% end %>
+  <div class="form-group">
+    <label class="control-label col-md-2 required" for="account_title">Title</label>
+    <div class="col-md-10">
+      <input id="account_title" type="text" class="form-control">
+      <span class="help-block">A human-friendly title for the repository. This can be changed later.</span>
+    </div>
+  </div>
 
   <div class="form-group">
-    <%= f.label :name %><br>
-    <%= f.text_field :name, class: 'form-control' %>
+    <%= f.label :name, 'Short name', class: 'col-md-2' %>
+    <div class="col-md-10">
+      <%= f.text_field :name, class: 'form-control' %>
+      <span class="help-block">A single or hyphenated name used for technical aspects of the repository (e.g., "acme" or "acme-library").</span>
+    </div>
   </div>
 
   <div class="actions">
-    <%= f.submit class: 'btn btn-primary' %>
+    <%= link_to 'Back', splash_path %>
+    <%= f.submit 'Next', class: 'btn btn-primary' %>
   </div>
 <% end %>

--- a/app/views/accounts/new.html.erb
+++ b/app/views/accounts/new.html.erb
@@ -1,5 +1,5 @@
-<h1>New Account</h1>
+<div class="row col-md-9 account-form">
+  <h1>Create a new repository</h1>
 
-<%= render 'new_form' %>
-
-<%= link_to 'Back', splash_path %>
+  <%= render 'new_form' %>
+</div>


### PR DESCRIPTION
Ideally this would also include removing the navbar below the brand bar, since on this page the user would have no reason to use the links or search box, but it's not clear to me how to remove it.

![new_account____hydra-in-a-box 2](https://cloud.githubusercontent.com/assets/101482/15949384/dd63e4f4-2e5b-11e6-8c97-eb71bc1ecfbc.png)

