### PR TITLE
Fix SQS job enqueueing problem

### DIFF
--- a/lib/active_job/queue_adapters/better_active_elastic_job_adapter.rb
+++ b/lib/active_job/queue_adapters/better_active_elastic_job_adapter.rb
@@ -3,6 +3,14 @@ require 'active_elastic_job'
 module ActiveJob
   module QueueAdapters
     class BetterActiveElasticJobAdapter < ActiveElasticJobAdapter
+      def enqueue(*args)
+        self.class.enqueue(*args)
+      end
+
+      def enqueue_at(*args)
+        self.class.enqueue_at(*args)
+      end
+
       class << self
         def aws_sqs_client
           @aws_sqs_client ||= Aws::SQS::Client.new

--- a/spec/lib/active_job/queue_adapters/better_active_elastic_job_adapter_spec.rb
+++ b/spec/lib/active_job/queue_adapters/better_active_elastic_job_adapter_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+require 'active_job/queue_adapters/better_active_elastic_job_adapter'
+
+RSpec.describe ActiveJob::QueueAdapters::BetterActiveElasticJobAdapter do
+  let(:queue_url) { 'http://example.com/queue/url' }
+  let(:account) { create(:account) }
+  let(:aws_sqs_client) { instance_double(Aws::SQS::Client) }
+  let(:job) { CreateSolrCollectionJob.new(account) }
+
+  before do
+    allow(Settings.active_job_queue).to receive(:url).and_return(queue_url)
+    allow(described_class).to receive(:aws_sqs_client).and_return(aws_sqs_client)
+  end
+
+  describe '#enqueue' do
+    it 'uses the configured queue' do
+      expect(aws_sqs_client).to receive(:send_message) do |msg|
+        expect(msg[:queue_url]).to eq queue_url
+      end
+
+      subject.enqueue job
+    end
+  end
+end


### PR DESCRIPTION
Rails 5 updated the adapter API, and upstream has hard-coded their class name.

Fixes #301

Also pursuing upstream at https://github.com/tawan/active-elastic-job/pull/44.