### PR TITLE
Use rails 5 CSRF default settings; fixes #303

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,8 @@
 class ApplicationController < ActionController::Base
+  # Prevent CSRF attacks by raising an exception.
+  # For APIs, you may want to use :null_session instead.
+  protect_from_forgery with: :exception, prepend: true
+
   force_ssl if: :ssl_configured?
 
   helper Openseadragon::OpenseadragonHelper
@@ -13,10 +17,6 @@ class ApplicationController < ActionController::Base
 
   include CurationConcerns::ThemedLayoutController
   layout 'sufia-one-column'
-
-  # Prevent CSRF attacks by raising an exception.
-  # For APIs, you may want to use :null_session instead.
-  protect_from_forgery with: :exception
 
   helper_method :peek_enabled?
 

--- a/config/initializers/new_framework_defaults.rb
+++ b/config/initializers/new_framework_defaults.rb
@@ -6,12 +6,6 @@
 #
 # Read the Rails 5.0 release notes for more info on each option.
 
-# Enable per-form CSRF tokens. Previous versions had false.
-Rails.application.config.action_controller.per_form_csrf_tokens = false
-
-# Enable origin-checking CSRF mitigation. Previous versions had false.
-Rails.application.config.action_controller.forgery_protection_origin_check = false
-
 # Make Ruby 2.4 preserve the timezone of the receiver when calling `to_time`.
 # Previous versions had false.
 ActiveSupport.to_time_preserves_timezone = false


### PR DESCRIPTION
Rails 5 no longer prepends the CSRF forgery check, so we need to ensure it appears at the top of the call chain. For some, yet to be determined, reason, simply moving it to the top of `ApplicationController` is insufficient.