### PR TITLE
Add docker-compose manifest for launching the stack using docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM ruby:2.3.1
+RUN apt-get update -qq && \
+    apt-get install -y build-essential libpq-dev nodejs libreoffice imagemagick unzip && \
+    rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /opt/fits && \
+    curl -fSL -o /opt/fits-0.6.2.zip http://projects.iq.harvard.edu/files/fits/files/fits-0.6.2.zip && \
+    cd /opt && unzip fits-0.6.2.zip && chmod +X fits-0.6.2/fits.sh
+
+RUN mkdir /data
+WORKDIR /data
+ADD Gemfile /data/Gemfile
+ADD Gemfile.lock /data/Gemfile.lock
+RUN bundle install
+ADD . /data
+RUN bundle exec rake assets:precompile
+EXPOSE 3000
+

--- a/Gemfile
+++ b/Gemfile
@@ -78,7 +78,6 @@ gem 'peek-git'
 gem 'peek-performance_bar'
 gem 'peek-pg'
 gem 'peek-redis'
-gem 'peek-sidekiq'
 
 gem 'flipflop', git: 'https://github.com/jcoyne/flipflop.git', branch: 'hydra'
 gem 'lograge'
@@ -88,11 +87,15 @@ gem 'zk'
 gem 'riiif', '~> 0.3'
 gem 'mods', '~> 2.1'
 
-gem 'sidekiq'
 gem 'iiif_manifest', '~> 0.1.2'
 
-gem 'active_elastic_job'
-gem 'fog-aws'
+group :aws do
+  gem 'active_elastic_job'
+  gem 'fog-aws'
+end
+
+gem 'sidekiq'
+gem 'peek-sidekiq'
 
 gem 'secure_headers'
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,33 @@
 
 Codename: Lerna
 
+## Running the stack
+
+### For development
+
+```bash
+$ solr_wrapper
+$ fcrepo_wrapper
+$ postgres -D ./db/postgres
+$ redis-server /usr/local/etc/redis.conf
+$ bin/setup
+$ bundle exec rails server
+```
+
+### On AWS
+
+AWS CloudFormation templates for the Lerna stack are available in a separate repository:
+
+https://github.com/hybox/aws
+
+### With Docker
+
+We distribute a `docker-compose.yml` configuration for running the Lerna stack and application using docker. Once you have [docker](https://docker.com) installed and running, launch the stack using e.g.:
+
+```bash
+$ docker-compose up -d
+```
+
 ## Switching accounts
 
 The recommend way to switch your current session from one account to another is by doing:

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -54,8 +54,9 @@ Rails.application.configure do
 
   # Use a real queuing backend for Active Job (and separate queues per environment)
   require 'active_job/queue_adapters/better_active_elastic_job_adapter'
-   config.active_job.queue_adapter     = :better_active_elastic_job
+  config.active_job.queue_adapter     = Settings.active_job.queue_adapter
   # config.active_job.queue_name_prefix = "lerna_#{Rails.env}"
+
   config.action_mailer.perform_caching = false
 
   # Ignore bad email addresses and do not raise email delivery errors.

--- a/config/initializers/apartment.rb
+++ b/config/initializers/apartment.rb
@@ -44,10 +44,12 @@ Apartment.configure do |config|
 
 end
 
-Apartment::Tenant.adapter.class.set_callback :switch, :after, ->() do
-  account = Account.find_by(tenant: current)
+Rails.application.config.after_initialize do
+  Apartment::Tenant.adapter.class.set_callback :switch, :after, ->() do
+    account = Account.find_by(tenant: current)
 
-  account.switch! if account
+    account.switch! if account
+  end if ActiveRecord::Base.connected?
 end
 
 Rails.application.config.middleware.use AccountElevator

--- a/config/initializers/redis_config.rb
+++ b/config/initializers/redis_config.rb
@@ -1,7 +1,7 @@
 config = YAML.load(ERB.new(IO.read(Rails.root + 'config' + 'redis.yml')).result)[Rails.env].with_indifferent_access
 require 'redis'
 Redis.current = begin
-                  Redis.new(config.merge(thread_safe: true))
+                  Redis.new(config.except(:sentinel).merge(thread_safe: true, sentinels: [(config[:sentinel] if config[:sentinel] && config[:sentinel][:host])]))
                 rescue
                   nil
                 end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,9 +1,13 @@
 config = YAML.load(ERB.new(IO.read(Rails.root + 'config' + 'redis.yml')).result)[Rails.env].with_indifferent_access
 
+redis_conn = proc {
+  Redis.new url: "redis://#{config[:host]}:#{config[:port]}/", role: :master, sentinels: [(config[:sentinel] if config[:sentinel] && config[:sentinel][:host])]
+}
+
 Sidekiq.configure_server do |s|
-  s.redis = { url: "redis://#{config[:host]}:#{config[:port]}/" }
+  s.redis = ConnectionPool.new(&redis_conn)
 end
 
 Sidekiq.configure_client do |s|
-  s.redis = { url: "redis://#{config[:host]}:#{config[:port]}/" }
+  s.redis = ConnectionPool.new(&redis_conn)
 end

--- a/config/redis.yml
+++ b/config/redis.yml
@@ -7,3 +7,6 @@ test:
 production:
   host: <%= ENV['REDIS_HOST'] || 'localhost' %>
   port: <%= ENV['REDIS_PORT'] || 6379 %>
+  sentinel:
+    host: <%= ENV['REDIS_SENTINEL_HOST'] %>
+    port: <%= ENV['REDIS_SENTINEL_PORT'] || 26379 %>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -39,6 +39,9 @@ solr:
 zookeeper:
   connection_str: "localhost:9983/configs"
 
+active_job:
+  queue_adapter: :async
+
 active_job_queue:
   url:
 

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -1,0 +1,37 @@
+version: '2'
+
+volumes:
+  fcrepo:
+  solr:
+  db:
+  redis:
+  exhibitor:
+  zookeeper:
+  app:
+
+networks:
+  external:
+  internal:
+
+services:
+  app:
+    build: .
+    restart: unless-stopped
+    environment:
+      - REDIS_HOST=redis_cluster
+      - DATABASE_URL=postgresql://postgres@db/postgres
+      - FEDORA_URL=http://fcrepo:8983/fedora/rest
+      - SOLR_URL=http://solr:8983/solr/
+      - SETTINGS__ACTIVE_JOB__QUEUE_ADAPTER=sidekiq
+      - SETTINGS__SOLR__URL=http://solr:8983/solr/
+      - SETTINGS__ZOOKEEPER__CONNECTION_STR=zookeeper_cluster:2181/configs
+      - RAILS_ENV=production
+      - RAILS_SERVE_STATIC_FILES=true
+      - RAILS_LOG_TO_STDOUT=true
+      - SECRET_KEY_BASE=asdf
+      - RAILS_CACHE_STORE_URL=memcache
+    volumes:
+      - .:/data
+      - app:/app
+    networks:
+      internal:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,217 @@
+version: '2'
+
+volumes:
+  fcrepo:
+  solr:
+  db:
+  redis:
+  zk1:
+  zk2:
+  zk3:
+  zkconf:
+  app:
+
+networks:
+  external:
+  internal:
+
+services:
+  zoo1:
+    image: zookeeper
+    restart: always
+    environment:
+      - ZOO_MY_ID=1
+      - ZOO_SERVERS=server.1=zoo1:2888:3888 server.2=zoo2:2888:3888 server.3=zoo3:2888:3888
+    expose:
+      - 2181
+      - 2888
+      - 3888
+    volumes:
+      - zk1:/data
+      - zkconf:/conf
+    networks:
+      internal:
+       aliases:
+         - zookeeper_cluster
+  zoo2:
+    image: zookeeper
+    restart: always
+    environment:
+      - ZOO_MY_ID=2
+      - ZOO_SERVERS=server.1=zoo1:2888:3888 server.2=zoo2:2888:3888 server.3=zoo3:2888:3888
+    expose:
+      - 2181
+      - 2888
+      - 3888
+    volumes:
+      - zk2:/data
+      - zkconf:/conf
+    networks:
+      internal:
+       aliases:
+         - zookeeper_cluster
+  zoo3:
+    image: zookeeper
+    restart: always
+    environment:
+      - ZOO_MY_ID=3
+      - ZOO_SERVERS=server.1=zoo1:2888:3888 server.2=zoo2:2888:3888 server.3=zoo3:2888:3888
+    expose:
+      - 2181
+      - 2888
+      - 3888
+    volumes:
+      - zk3:/data
+      - zkconf:/conf
+    networks:
+      internal:
+       aliases:
+         - zookeeper_cluster
+
+  solr:
+    image: solr
+    command: solr -c -f -z zookeeper_cluster:2181
+    depends_on:
+      - zoo1
+      - zoo2
+      - zoo3
+    expose:
+      - 8983
+    volumes:
+      - .:/app
+      - solr:/data
+    networks:
+      internal:
+
+  fcrepo:
+    image: cbeer/fcrepo4
+    expose:
+      - 8983
+    volumes:
+      - fcrepo:/data
+    environment:
+      - JAVA_OPTS="${JAVA_OPTS} -Dfcrepo.modeshape.configuration=\"classpath:/config/minimal-default/repository.json\""
+    networks:
+      internal:
+
+  db:
+    image: postgres
+    volumes:
+      - db:/var/lib/postgresql/data
+    networks:
+      internal:
+
+  app:
+    build: .
+    environment:
+      - REDIS_HOST=redis_cluster
+      - REDIS_SENTINEL_HOST=redis_sentinel
+      - DATABASE_URL=postgresql://postgres@db/postgres
+      - FEDORA_URL=http://fcrepo:8983/fedora/rest
+      - SOLR_URL=http://solr:8983/solr/
+      - SETTINGS__ACTIVE_JOB__QUEUE_ADAPTER=sidekiq
+      - SETTINGS__SOLR__URL=http://solr:8983/solr/
+      - SETTINGS__ZOOKEEPER__CONNECTION_STR=zookeeper_cluster:2181/configs
+      - RAILS_ENV=production
+      - RAILS_SERVE_STATIC_FILES=true
+      - RAILS_LOG_TO_STDOUT=true
+      - SECRET_KEY_BASE=asdf
+      - RAILS_CACHE_STORE_URL=memcache
+    volumes:
+      - app:/data/public/uploads
+    networks:
+      internal:
+
+  web:
+    extends: app
+    command: bundle exec rails server -p 3000 -b '0.0.0.0'
+    depends_on:
+      - db
+      - solr
+      - fcrepo
+      - redis_sentinel
+      - zoo1
+      - zoo2
+      - zoo3
+      - memcache
+      - db_migrate
+    expose:
+      - 3000
+
+  workers:
+    extends: app
+    command: bundle exec sidekiq
+    depends_on:
+      - db
+      - solr
+      - fcrepo
+      - redis_sentinel
+      - zoo1
+      - zoo2
+      - zoo3
+      - initialize_app
+      - db_migrate
+  
+  initialize_app:
+    extends: app
+    restart: on-failure
+    command: bundle exec rails zookeeper:upload
+    depends_on:
+      - zoo1
+      - zoo2
+      - zoo3
+
+  db_migrate:
+    extends: app
+    restart: on-failure
+    command: bundle exec rails db:migrate
+    depends_on:
+      - db
+
+  lb:
+    image: dockercloud/haproxy:1.5.3
+    links:
+      - web
+    environment:
+      - DOCKER_TLS_VERIFY
+      - DOCKER_HOST
+      - DOCKER_CERT_PATH
+    volumes:
+      - $DOCKER_CERT_PATH:$DOCKER_CERT_PATH
+    ports:
+      - 8080:80
+      - 8443:443
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    networks:
+      internal:
+      external:
+
+  redis_primary:
+    extends: redis
+    command: redis-server
+    volumes:
+      - redis:/data
+
+  redis:
+    image: redis:3
+    command: redis-server --slaveof redis_primary 6379
+    networks:
+      internal:
+        aliases:
+          - redis_cluster
+
+  redis_sentinel:
+    image: s7anley/redis-sentinel-docker
+    environment:
+      - MASTER=redis_primary
+      - MASTER_NAME=redis_cluster
+    links:
+      - redis_primary
+    networks:
+      internal:
+
+  memcache:
+    image: memcached
+    networks:
+      internal:


### PR DESCRIPTION
- [ ] get fcrepo using the mounted volume, or clustered using postgres
- [x] exhibitor/zookeeper occasionally fails to form a cluster fast enough
- [x] documentation on how to spin the thing up:

```
# directions for configuring a wildcard DNS route

$ docker-compose up

# visit localhost:8080 in your browser

# scale up:
$ docker-compose scale web=3 workers=2 solr=3 zookeeper=2 redis=2 redis_sentinel=2
```

- [ ] test with docker swarm