### PR TITLE
Redirect to splash_path with the route_set

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -27,7 +27,7 @@ class ApplicationController < ActionController::Base
 
   rescue_from Apartment::TenantNotFound do
     raise ActionController::RoutingError, 'Not Found' unless worker? || base_host?
-    redirect_to splash_path
+    redirect_to main_app.splash_path
   end
 
   private


### PR DESCRIPTION
The controller that is extending ApplicationController may not be using
the main application route set.  Fixes #367