### PR TITLE
Update the admin sidebar to use standard bootstrap components

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,7 +36,7 @@ GIT
 
 GIT
   remote: https://github.com/projecthydra/sufia.git
-  revision: 0ff1da077b9e109fddd658a74811a28c2bd699ab
+  revision: 743ae5d39292147fe4f992f70bdd71ec268a37be
   specs:
     sufia (7.2.0)
       almond-rails (~> 0.0.1)

--- a/app/assets/stylesheets/lerna.scss
+++ b/app/assets/stylesheets/lerna.scss
@@ -112,3 +112,11 @@ footer.navbar {
     height: 100%;
   }
 }
+
+#sidebar {
+  .nav {
+    .nav {
+      text-indent: 2ch;
+    }
+  }
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,12 @@
 module ApplicationHelper
   include ::SufiaHelper
   include ContentBlockHelper
+
+  def nav_link(href)
+    content_tag(:li, class: ('active' if current_page?(href))) do
+      link_to(href) do
+        yield
+      end
+    end
+  end
 end

--- a/app/views/sufia/admin/_sidebar.html.erb
+++ b/app/views/sufia/admin/_sidebar.html.erb
@@ -1,63 +1,48 @@
-                <!-- START X-NAVIGATION -->
-                <ul class="x-navigation">
-                    <li class="xn-logo">
-                        <%= link_to main_app.root_path do %>
-                          <span class="glyphicon glyphicon-globe"></span>
-                          <%= application_name %>
-                        <% end %>
-                        <a href="#" class="x-navigation-control"></a>
-                    </li>
-                    <li><%= link_to sufia.admin_stats_path do %>
-                          <span class="fa fa-bar-chart"></span> <%= t('sufia.admin.sidebar.statistics') %>
-                        <% end %>
-                    </li>
+<ul class="nav nav-pills nav-stacked">
+  <%= nav_link(sufia.admin_stats_path) do %>
+    <span class="fa fa-bar-chart"></span> <%= t('sufia.admin.sidebar.statistics') %>
+  <% end %>
 
-                    <li class="xn-title">Configuration</li>
-                    <li class="xn-openable">
-                      <a href="#">
-                        <span class="fa fa-cog"></span>
-                        <span class="xn-text"><%= t('sufia.admin.sidebar.settings') %></span>
-                      </a>
-                      <ul>
-                        <% if can? :manage, Site %>
-                          <li><%= link_to main_app.edit_site_labels_path do %>
-                            <span class="fa fa-institution"></span> <%= t('sufia.admin.sidebar.labels') %>
-                              <% end %>
-                          </li>
-                          <li><%= link_to main_app.edit_site_content_blocks_path do %>
-                            <span class="fa fa-file-text-o"></span> <%= t('sufia.admin.sidebar.content_blocks') %>
-                              <% end %>
-                          </li>
-                        <% end %>
+    <li class="h5">Configuration</li>
+    <li>
+      <a href="#">
+        <span class="fa fa-cog"></span>
+        <span><%= t('sufia.admin.sidebar.settings') %></span>
+      </a>
+      <ul class="nav nav-pills nav-stacked">
+        <% if can? :manage, Site %>
+          <%= nav_link(main_app.edit_site_labels_path) do %>
+            <span class="fa fa-institution"></span> <%= t('sufia.admin.sidebar.labels') %>
+          <% end %>
 
-                        <li><%= link_to sufia.admin_features_path do %>
-                              <span class="fa fa-wrench"></span> Technical
-                            <% end %>
-                        </li>
-                      </ul>
-                    </li>
+          <%= nav_link(main_app.edit_site_content_blocks_path) do %>
+            <span class="fa fa-file-text-o"></span> <%= t('sufia.admin.sidebar.content_blocks') %>
+          <% end %>
+        <% end %>
 
-                    <li><%= link_to sufia.admin_admin_sets_path do %>
-                      <span class="fa fa-sitemap"></span> <%= t('sufia.admin.sidebar.admin_sets') %>
-                        <% end %>
-                    </li>
+        <%= nav_link(sufia.admin_features_path) do %>
+          <span class="fa fa-wrench"></span> Technical
+        <% end %>
+      </ul>
+    </li>
 
-                    <% if can? :manage, Role %>
-                      <li><%= link_to main_app.site_roles_path do %>
-                        <span class="fa fa-user"></span> <%= t('sufia.admin.sidebar.roles_and_permissions') %>
-                          <% end %>
-                      </li>
-                    <% end %>
+    <%= nav_link(sufia.admin_admin_sets_path) do %>
+      <span class="fa fa-sitemap"></span> <%= t('sufia.admin.sidebar.admin_sets') %>
+    <% end %>
 
-                    <% if can? :manage, Account %>
-                      <li>
-                        <%= link_to main_app.accounts_path do %>
-                          <span class="fa fa-gears"></span> <%= t('sufia.admin.sidebar.accounts') %>
-                        <% end %>
-                      </li>
-                    <% elsif Site.account && can?(:manage, Site.account) %>
-                       <li><%= link_to 'Account', main_app.account_path(Site.account) %></li>
-                    <% end %>
+    <% if can? :manage, Role %>
+      <%= nav_link(main_app.site_roles_path) do %>
+        <span class="fa fa-user"></span> <%= t('sufia.admin.sidebar.roles_and_permissions') %>
+      <% end %>
+    <% end %>
 
-                </ul>
-
+    <% if can? :manage, Account %>
+      <%= nav_link(main_app.accounts_path) do %>
+        <span class="fa fa-gears"></span> <%= t('sufia.admin.sidebar.accounts') %>
+      <% end %>
+    <% elsif Site.account && can?(:manage, Site.account) %>
+      <%= nav_link(main_app.account_path(Site.account)) do %>
+        Account
+      <% end %>
+    <% end %>
+</ul>

--- a/spec/features/admin_dashboard_spec.rb
+++ b/spec/features/admin_dashboard_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Admin Dashboard' do
 
     it 'shows the admin page' do
       visit Sufia::Engine.routes.url_helpers.admin_path
-      within '.page-sidebar' do
+      within '#sidebar' do
         expect(page).to have_link('Statistics')
         expect(page).to have_link('Labels')
         expect(page).to have_link('Content Blocks')

--- a/spec/features/labels_spec.rb
+++ b/spec/features/labels_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Site labels configuration' do
         visit edit_site_labels_path
         fill_in 'Application name', with: 'Custom Name'
         click_on 'Update Site'
-        expect(page).to have_css '.xn-logo', text: 'Custom Name'
+        expect(page).to have_css '.navbar-brand', text: 'Custom Name'
       end
 
       it 'updates the application name in the <head> <title>' do


### PR DESCRIPTION
Not great right now, but at least it's a start.

<img width="509" alt="screen shot 2016-10-25 at 4 04 35 pm" src="https://cloud.githubusercontent.com/assets/111218/19707501/c3bb1508-9acc-11e6-80a8-58a430215498.png">
